### PR TITLE
Use latest time to prevent double printing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod error;
 mod nested_stacks;
 mod stack_status;
 mod tail;
+mod utils;
 mod writer;
 
 use crate::error::Error;
@@ -80,7 +81,6 @@ async fn main() {
 
     tracing::info!(stack_name = %opts.stack_name, since = %since, "tailing stack events");
 
-    let mut seen_events = HashSet::new();
     let original_stack_name = opts.stack_name.clone();
 
     let mut stdout = StandardStream::stdout(ColorChoice::Auto);
@@ -108,7 +108,7 @@ async fn main() {
             nested: opts.nested,
         };
 
-        let mut tail = Tail::new(config, Arc::new(client), &mut writer, &mut seen_events);
+        let mut tail = Tail::new(config, Arc::new(client), &mut writer);
 
         tracing::info!("prefetching tasks");
         match tail.prefetch().await {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,8 @@
+use chrono::{DateTime, Utc};
+use eyre::{Result, WrapErr};
+
+pub(crate) fn parse_event_datetime(dt: &str) -> Result<DateTime<Utc>> {
+    Ok(DateTime::parse_from_rfc3339(dt)
+        .wrap_err("parsing timestamp")?
+        .with_timezone(&Utc))
+}


### PR DESCRIPTION
We know that the events are guaranteed to come in in reverse chronological order, so we can optimise - if the current event is older than what we've already seen then we don't need to continue. This will help greatly when fetching stacks with long histories - we no longer have to fetch the entire history of the stack before printing.